### PR TITLE
Fixed Authenticate call getting blocked when touchid is not available

### DIFF
--- a/touchid.go
+++ b/touchid.go
@@ -25,6 +25,9 @@ int Authenticate(char const* reason) {
         }
         dispatch_semaphore_signal(sema);
       }];
+  } else {
+    result = 3;
+    dispatch_semaphore_signal(sema);
   }
 
   dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
@@ -50,6 +53,8 @@ func Authenticate(reason string) (bool, error) {
 		return true, nil
 	case 2:
 		return false, nil
+	case 3:
+		return true, nil
 	}
 
 	return false, errors.New("Error occurred accessing biometrics")


### PR DESCRIPTION
We are waiting on semaphore but that semaphore is never signaled when canEvaluatePolicy is returned false. if canEvaluatePolicy return then it means most likely that touch id is not present and I believe it should return true in that case since biometric itself is not present